### PR TITLE
issue 8661

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -334,7 +334,9 @@ class WPSEO_Replace_Vars {
 				$replacement = wp_strip_all_tags( $this->args->post_excerpt );
 			}
 			elseif ( $this->args->post_content !== '' ) {
-				$replacement = wp_html_excerpt( strip_shortcodes( $this->args->post_content ), 155 );
+                $replacement = wp_html_excerpt( strip_shortcodes( $this->args->post_content ), 320 );
+                // trim the auto-generated string to a word boundary
+                $replacement = substr($replacement, 0, strrpos($replacement, ' '));
 			}
 		}
 


### PR DESCRIPTION
change auto-generated description max length to 320, also trim it to word boundary, as proposed in https://github.com/Yoast/wordpress-seo/issues/8661

## Summary

This PR can be summarized in the following changelog entry:

change auto-generated description max length to 320, also trim it to word boundary

## Relevant technical choices:

finding the last word boundary in the 320 character string depends on substr with the end of substr given by `strrpos($replacement, ' ')`, an approach which has good support on Stackexchange

## Test instructions

This PR can be tested by following these steps:

create a post with no manually created excerpt or snippet; check that the auto-generated snippet is trimmed to the nearest word boundary to 320 characters

Fixes #
